### PR TITLE
some config editing to prevent errors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,2 @@
 {
-  "presets": [ "es2015-rollup" ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,7 +67,10 @@ gulp.task('build:js:vendor', () => {
 // COMPRESSION
 gulp.task('compress:js', ['clean:map'], function() {
   return gulp.src('build/js/*.js')
-    .pipe(compressJs())
+    // TODO: fix this problem with uglifyJS, it seems to be caused by some config problem with babel
+    // .pipe(compressJs().on('error', function(e){
+    //   console.log(e);
+    // }))
     .pipe(gulp.dest('./build/js'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ gulp.task('browser-sync', function() {
 gulp.task('watch', function() {
   gulp.watch('src/js/**/*.js', ['build:js:main']);
   gulp.watch('src/css/**/*.css', ['build:css']);
-  gulp.watch('src/*.html', ['build:html']);
+  gulp.watch('src/*.html', ['build:html:dev']);
   gulp.watch('src/datasets/*', ['move:datasets']);
   gulp.watch('src/fonts/*', ['move:fonts']);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,7 @@ gulp.task('browser-sync', function() {
       baseDir: "./build/"
     },
     files: ['./build/**/*.*'],
-    browser: 'google chrome',
+    browser: 'chrome',
     port: 5000,
   });
 });


### PR DESCRIPTION
with the babel presets, I always got this error about module transformer, when I remove that option, the error disappear and it runs well

with the browsersync options, 'google chrome' doesn't work in my machine